### PR TITLE
Fixing squid:S1118 -  Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/audit4j/core/Configurations.java
+++ b/src/main/java/org/audit4j/core/Configurations.java
@@ -52,9 +52,9 @@ public class Configurations {
     static final String ENVIRONMENT_CONFIG_VARIABLE_NAME = "AUDIT4J_CONF_FILE_PATH";
 
     /**
-     * Instantiates a new configurations.
+     *  
      */
-    public Configurations() {
+    private Configurations() {
 
     }
     

--- a/src/main/java/org/audit4j/core/CoreConstants.java
+++ b/src/main/java/org/audit4j/core/CoreConstants.java
@@ -147,5 +147,9 @@ public final class CoreConstants {
 
     /** The Constant ENCODE_UTF8. */
     public static final String ENCODE_UTF8 = "UTF-8";
+    
+    private CoreConstants(){
+    	
+    }
 
 }

--- a/src/main/java/org/audit4j/core/ErrorGuide.java
+++ b/src/main/java/org/audit4j/core/ErrorGuide.java
@@ -59,7 +59,14 @@ public final class ErrorGuide {
     
     /** The Constant LAYOUT_ERROR. */
     public static final String OPTION_ERROR = ERROR_URL + "optionError";
-    
+   
+    /**
+     * private constructor to avoid instantiation of this class
+     */
+    private ErrorGuide(){
+    	
+    }
+ 
     /**
      * Gets the guide.
      *

--- a/src/main/java/org/audit4j/core/TroubleshootManager.java
+++ b/src/main/java/org/audit4j/core/TroubleshootManager.java
@@ -38,6 +38,13 @@ public final class TroubleshootManager {
 
     /** The Constant MAX_PORT_NUMBER. */
     public static final int MAX_PORT_NUMBER = 49151;
+    
+    /**
+     * private constructor to avoid instantiation of this class
+     */
+    private TroubleshootManager(){
+    	
+    }
 
     /**
      * Troubleshoot event.

--- a/src/main/java/org/audit4j/core/annotation/DeIdentifyUtil.java
+++ b/src/main/java/org/audit4j/core/annotation/DeIdentifyUtil.java
@@ -29,6 +29,14 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class DeIdentifyUtil {
 
+
+    /**
+     * private constructor to avoid instantiation of this class
+     */
+    private DeIdentifyUtil(){
+    	
+    }
+
 	/**
 	 * Deidentify left.
 	 *

--- a/src/main/java/org/audit4j/core/dto/AuditLevel.java
+++ b/src/main/java/org/audit4j/core/dto/AuditLevel.java
@@ -29,5 +29,12 @@ public class AuditLevel {
 
 	/** The Constant DEFAULT_LEVEL. */
 	public static final String DEFAULT_LEVEL = "default";
+	
+	 /**
+     * private constructor to avoid instantiation of this class
+     */
+    private AuditLevel(){
+    	
+    }
 
 }

--- a/src/main/java/org/audit4j/core/extra/scannotation/ClasspathUrlFinder.java
+++ b/src/main/java/org/audit4j/core/extra/scannotation/ClasspathUrlFinder.java
@@ -18,6 +18,13 @@ import java.util.StringTokenizer;
 public class ClasspathUrlFinder
 {
 
+	 /**
+     * private constructor to avoid instantiation of this class
+     */
+    private ClasspathUrlFinder(){
+    	
+    }
+    
    /**
     * Find the classpath URLs for a specific classpath resource.  The classpath URL is extracted
     * from loader.getResources() using the baseResource.

--- a/src/main/java/org/audit4j/core/extra/scannotation/IteratorFactory.java
+++ b/src/main/java/org/audit4j/core/extra/scannotation/IteratorFactory.java
@@ -6,6 +6,14 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class IteratorFactory {
     private static final ConcurrentHashMap<String, DirectoryIteratorFactory> registry = new ConcurrentHashMap<String, DirectoryIteratorFactory>();
+    
+    /**
+     * private constructor to avoid instantiation of this class
+     */
+    private IteratorFactory(){
+    	
+    }
+    
     static {
         registry.put("file", new FileProtocolIteratorFactory());
     }

--- a/src/main/java/org/audit4j/core/handler/file/archive/FTPArchiveClient.java
+++ b/src/main/java/org/audit4j/core/handler/file/archive/FTPArchiveClient.java
@@ -32,6 +32,13 @@ import org.apache.commons.net.util.TrustManagerUtils;
  * @author <a href="mailto:janith3000@gmail.com">Janith Bandara</a>
  */
 public final class FTPArchiveClient {
+	
+	/**
+     * private constructor to avoid instantiation of this class
+     */
+    private FTPArchiveClient(){
+    	
+    }
 
     /** The Constant USAGE. */
     public static final String USAGE = "Usage: ftp [options] <hostname> <username> <password> [<remote file> [<local file>]]\n"

--- a/src/main/java/org/audit4j/core/jmx/JMXUtils.java
+++ b/src/main/java/org/audit4j/core/jmx/JMXUtils.java
@@ -10,6 +10,13 @@ import javax.management.ObjectName;
  * @since 2.4.0
  */
 public class JMXUtils {
+	
+	/**
+     * private constructor to avoid instantiation of this class
+     */
+    private JMXUtils(){
+    	
+    }
 
     /**
      * Gets the object name.

--- a/src/main/java/org/audit4j/core/schedule/TaskUtils.java
+++ b/src/main/java/org/audit4j/core/schedule/TaskUtils.java
@@ -16,6 +16,14 @@ import org.audit4j.core.schedule.util.ErrorHandler;
  * @since 3.0
  */
 public abstract class TaskUtils {
+	
+	/**
+     * private constructor to avoid instantiation of this class
+     */
+    private TaskUtils(){
+    	
+    }
+
     /**
      * An ErrorHandler strategy that will log the Exception but perform no
      * further handling. This will suppress the error so that subsequent

--- a/src/main/java/org/audit4j/core/schedule/util/ClassUtils.java
+++ b/src/main/java/org/audit4j/core/schedule/util/ClassUtils.java
@@ -5,6 +5,13 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class ClassUtils {
+	
+	/**
+     * private constructor to avoid instantiation of this class
+     */
+    private ClassUtils(){
+    	
+    }
 
     /**
      * Determine whether the given class has a public method with the given

--- a/src/main/java/org/audit4j/core/schedule/util/StringUtils.java
+++ b/src/main/java/org/audit4j/core/schedule/util/StringUtils.java
@@ -21,6 +21,13 @@ public class StringUtils {
     private static final String TOP_PATH = "..";
     private static final String CURRENT_PATH = ".";
     private static final char EXTENSION_SEPARATOR = '.';
+    
+    /**
+     * private constructor to avoid instantiation of this class
+     */
+    private StringUtils(){
+    	
+    }
 
     // ---------------------------------------------------------------------
     // General convenience methods for working with Strings

--- a/src/main/java/org/audit4j/core/util/EnvUtil.java
+++ b/src/main/java/org/audit4j/core/util/EnvUtil.java
@@ -33,6 +33,14 @@ import org.audit4j.core.Configurations;
  */
 public class EnvUtil {
 
+	  
+    /**
+     * private constructor to avoid instantiation of this class
+     */
+    private EnvUtil(){
+    	
+    }
+    
     /**
      * Checks if is jD k_ n_ or higher.
      * 

--- a/src/main/java/org/audit4j/core/util/Log.java
+++ b/src/main/java/org/audit4j/core/util/Log.java
@@ -52,6 +52,12 @@ public class Log {
     private static PrintStream errorStream = System.err;
 
     /**
+     * private constructor to avoid instantiation of this class
+     */
+    private Log(){
+    	
+    }
+    /**
      * Write information in the console.
      * 
      * @param message

--- a/src/main/java/org/audit4j/core/web/ContextConfigParams.java
+++ b/src/main/java/org/audit4j/core/web/ContextConfigParams.java
@@ -44,4 +44,10 @@ class ContextConfigParams {
     
     /** The Constant PARAM_PROPERTIES. */
     static final String PARAM_PROPERTIES = "properties";
+    /**
+     * private constructor to avoid instantiation of this class
+     */
+    private ContextConfigParams(){
+    	
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1118 -  Utility classes should not have public constructors". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1118


Please let me know if you have any questions.
Sameer Misger