### PR TITLE
Fixing squid:S1197,  Fixing squid:S1125

### DIFF
--- a/src/main/java/org/audit4j/core/filter/POJOQuery.java
+++ b/src/main/java/org/audit4j/core/filter/POJOQuery.java
@@ -294,9 +294,9 @@ public class POJOQuery<O> {
 		 * @return true, if successful
 		 */
 		public boolean operaterProceed() {
-			if (operator.equals(Operator.AND) && result == false) {
+			if (operator.equals(Operator.AND) && !result) {
 				return false;
-			} else if (operator.equals(Operator.OR) && result == true) {
+			} else if (operator.equals(Operator.OR) && result) {
 				return false;
 			}
 			return true;

--- a/src/main/java/org/audit4j/core/handler/file/archive/FTPArchiveClient.java
+++ b/src/main/java/org/audit4j/core/handler/file/archive/FTPArchiveClient.java
@@ -139,7 +139,7 @@ public final class FTPArchiveClient {
                 trustmgr = args[++base];
             } else if (args[base].equals("-PrH")) {
                 proxyHost = args[++base];
-                String parts[] = proxyHost.split(":");
+                String[] parts = proxyHost.split(":");
                 if (parts.length == 2) {
                     proxyHost = parts[0];
                     proxyPort = Integer.parseInt(parts[1]);
@@ -167,7 +167,7 @@ public final class FTPArchiveClient {
 
         String server = args[base++];
         int port = 0;
-        String parts[] = server.split(":");
+        String[] parts = server.split(":");
         if (parts.length == 2) {
             server = parts[0];
             port = Integer.parseInt(parts[1]);
@@ -202,7 +202,7 @@ public final class FTPArchiveClient {
             } else if (protocol.equals("false")) {
                 ftps = new FTPSClient(false);
             } else {
-                String prot[] = protocol.split(",");
+                String[] prot = protocol.split(",");
                 if (prot.length == 1) { // Just protocol
                     ftps = new FTPSClient(protocol);
                 } else { // protocol,true|false


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1197- Array designators "[]" should be on the type, not the variable,  squid:S1125- Literal boolean values should not be used in condition expressions". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.
Sameer Misger