### PR TITLE
Fixing squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/org/audit4j/core/ValidationManager.java
+++ b/src/main/java/org/audit4j/core/ValidationManager.java
@@ -96,7 +96,7 @@ public final class ValidationManager {
         } else {
             retVal = false;
         }
-        return (retVal);
+        return retVal;
     }
 
     /**
@@ -108,8 +108,8 @@ public final class ValidationManager {
      */
     private static boolean implementsInterface(final Object o) {
         final boolean retVal;
-        retVal = ((o instanceof Serializable) || (o instanceof Externalizable));
-        return (retVal);
+        retVal = (o instanceof Serializable) || (o instanceof Externalizable);
+        return retVal;
     }
 
     /**
@@ -131,7 +131,7 @@ public final class ValidationManager {
             stream.writeObject(o);
             // could also re-serilalize at this point too
         } catch (final IOException ex) {
-            return (false);
+            return false;
         } finally {
             if (stream != null) {
                 try {
@@ -142,7 +142,7 @@ public final class ValidationManager {
             }
         }
 
-        return (true);
+        return true;
     }
 
     public static void main(String[] args) {

--- a/src/main/java/org/audit4j/core/schedule/ConcurrentTaskScheduler.java
+++ b/src/main/java/org/audit4j/core/schedule/ConcurrentTaskScheduler.java
@@ -141,8 +141,8 @@ public class ConcurrentTaskScheduler extends ConcurrentTaskExecutor implements T
     public final void setScheduledExecutor(ScheduledExecutorService scheduledExecutor) {
         if (scheduledExecutor != null) {
             this.scheduledExecutor = scheduledExecutor;
-            this.enterpriseConcurrentScheduler = (managedScheduledExecutorServiceClass != null && managedScheduledExecutorServiceClass
-                    .isInstance(scheduledExecutor));
+            this.enterpriseConcurrentScheduler = managedScheduledExecutorServiceClass != null && managedScheduledExecutorServiceClass
+                    .isInstance(scheduledExecutor);
         } else {
             this.scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
             this.enterpriseConcurrentScheduler = false;
@@ -173,8 +173,8 @@ public class ConcurrentTaskScheduler extends ConcurrentTaskExecutor implements T
             if (this.enterpriseConcurrentScheduler) {
                 return new EnterpriseConcurrentTriggerScheduler().schedule(decorateTask(task, true), trigger);
             } else {
-                ErrorHandler errorHandler = (this.errorHandler != null ? this.errorHandler : TaskUtils
-                        .getDefaultErrorHandler(true));
+                ErrorHandler errorHandler = this.errorHandler != null ? this.errorHandler : TaskUtils
+                        .getDefaultErrorHandler(true);
                 return new ReschedulingRunnable(task, trigger, this.scheduledExecutor, errorHandler).schedule();
             }
         } catch (RejectedExecutionException ex) {

--- a/src/main/java/org/audit4j/core/schedule/CronTrigger.java
+++ b/src/main/java/org/audit4j/core/schedule/CronTrigger.java
@@ -83,8 +83,8 @@ public class CronTrigger implements Trigger {
      */
     @Override
     public boolean equals(Object obj) {
-        return (this == obj || (obj instanceof CronTrigger && this.sequenceGenerator
-                .equals(((CronTrigger) obj).sequenceGenerator)));
+        return this == obj || (obj instanceof CronTrigger && this.sequenceGenerator
+                .equals(((CronTrigger) obj).sequenceGenerator));
     }
 
     /**

--- a/src/main/java/org/audit4j/core/schedule/PeriodicTrigger.java
+++ b/src/main/java/org/audit4j/core/schedule/PeriodicTrigger.java
@@ -57,7 +57,7 @@ public class PeriodicTrigger implements Trigger {
      */
     public PeriodicTrigger(long period, TimeUnit timeUnit) {
         //Assert.isTrue(period >= 0, "period must not be negative");
-        this.timeUnit = (timeUnit != null ? timeUnit : TimeUnit.MILLISECONDS);
+        this.timeUnit = timeUnit != null ? timeUnit : TimeUnit.MILLISECONDS;
         this.period = this.timeUnit.toMillis(period);
     }
 
@@ -114,7 +114,7 @@ public class PeriodicTrigger implements Trigger {
             return false;
         }
         PeriodicTrigger other = (PeriodicTrigger) obj;
-        return (this.fixedRate == other.fixedRate && this.initialDelay == other.initialDelay && this.period == other.period);
+        return this.fixedRate == other.fixedRate && this.initialDelay == other.initialDelay && this.period == other.period;
     }
 
     /**

--- a/src/main/java/org/audit4j/core/schedule/ReschedulingRunnable.java
+++ b/src/main/java/org/audit4j/core/schedule/ReschedulingRunnable.java
@@ -190,6 +190,6 @@ class ReschedulingRunnable extends DelegatingErrorHandlingRunnable implements Sc
             return 0;
         }
         long diff = getDelay(TimeUnit.MILLISECONDS) - other.getDelay(TimeUnit.MILLISECONDS);
-        return (diff == 0 ? 0 : ((diff < 0) ? -1 : 1));
+        return diff == 0 ? 0 : (diff < 0) ? -1 : 1;
     }
 }

--- a/src/main/java/org/audit4j/core/schedule/TaskUtils.java
+++ b/src/main/java/org/audit4j/core/schedule/TaskUtils.java
@@ -55,7 +55,7 @@ public abstract class TaskUtils {
         if (task instanceof DelegatingErrorHandlingRunnable) {
             return (DelegatingErrorHandlingRunnable) task;
         }
-        ErrorHandler eh = (errorHandler != null ? errorHandler : getDefaultErrorHandler(isRepeatingTask));
+        ErrorHandler eh = errorHandler != null ? errorHandler : getDefaultErrorHandler(isRepeatingTask);
         return new DelegatingErrorHandlingRunnable(task, eh);
     }
 
@@ -69,7 +69,7 @@ public abstract class TaskUtils {
      * @return the default error handler
      */
     public static ErrorHandler getDefaultErrorHandler(boolean isRepeatingTask) {
-        return (isRepeatingTask ? LOG_AND_SUPPRESS_ERROR_HANDLER : LOG_AND_PROPAGATE_ERROR_HANDLER);
+        return isRepeatingTask ? LOG_AND_SUPPRESS_ERROR_HANDLER : LOG_AND_PROPAGATE_ERROR_HANDLER;
     }
 
     /**

--- a/src/main/java/org/audit4j/core/schedule/ThreadPoolTaskScheduler.java
+++ b/src/main/java/org/audit4j/core/schedule/ThreadPoolTaskScheduler.java
@@ -304,8 +304,8 @@ public class ThreadPoolTaskScheduler implements AsyncTaskExecutor, SchedulingTas
     public ScheduledFuture<?> schedule(Runnable task, Trigger trigger) {
         ScheduledExecutorService executor = getScheduledExecutor();
         try {
-            ErrorHandler errorHandler = (this.errorHandler != null ? this.errorHandler : TaskUtils
-                    .getDefaultErrorHandler(true));
+            ErrorHandler errorHandler = this.errorHandler != null ? this.errorHandler : TaskUtils
+                    .getDefaultErrorHandler(true);
             return new ReschedulingRunnable(task, trigger, executor, errorHandler).schedule();
         } catch (RejectedExecutionException ex) {
             throw new TaskRejectedException("Executor [" + executor + "] did not accept task: " + task, ex);

--- a/src/main/java/org/audit4j/core/schedule/util/ClassUtils.java
+++ b/src/main/java/org/audit4j/core/schedule/util/ClassUtils.java
@@ -29,7 +29,7 @@ public class ClassUtils {
      * @see Class#getMethod
      */
     public static boolean hasMethod(Class<?> clazz, String methodName, Class<?>... paramTypes) {
-        return (getMethodIfAvailable(clazz, methodName, paramTypes) != null);
+        return getMethodIfAvailable(clazz, methodName, paramTypes) != null;
     }
 
     /**

--- a/src/main/java/org/audit4j/core/schedule/util/CustomizableThreadCreator.java
+++ b/src/main/java/org/audit4j/core/schedule/util/CustomizableThreadCreator.java
@@ -38,7 +38,7 @@ public class CustomizableThreadCreator implements Serializable {
      *            the prefix to use for the names of newly created threads
      */
     public CustomizableThreadCreator(String threadNamePrefix) {
-        this.threadNamePrefix = (threadNamePrefix != null ? threadNamePrefix : getDefaultThreadNamePrefix());
+        this.threadNamePrefix = threadNamePrefix != null ? threadNamePrefix : getDefaultThreadNamePrefix();
     }
 
     /**
@@ -46,7 +46,7 @@ public class CustomizableThreadCreator implements Serializable {
      * is "SimpleAsyncTaskExecutor-".
      */
     public void setThreadNamePrefix(String threadNamePrefix) {
-        this.threadNamePrefix = (threadNamePrefix != null ? threadNamePrefix : getDefaultThreadNamePrefix());
+        this.threadNamePrefix = threadNamePrefix != null ? threadNamePrefix : getDefaultThreadNamePrefix();
     }
 
     /**

--- a/src/main/java/org/audit4j/core/schedule/util/StringUtils.java
+++ b/src/main/java/org/audit4j/core/schedule/util/StringUtils.java
@@ -48,7 +48,7 @@ public class StringUtils {
      * @since 3.2.1
      */
     public static boolean isEmpty(Object str) {
-        return (str == null || "".equals(str));
+        return str == null || "".equals(str);
     }
 
     /**
@@ -70,7 +70,7 @@ public class StringUtils {
      * @see #hasText(String)
      */
     public static boolean hasLength(CharSequence str) {
-        return (str != null && str.length() > 0);
+        return str != null && str.length() > 0;
     }
 
     /**
@@ -470,7 +470,7 @@ public class StringUtils {
      *         input was {@code null}
      */
     public static String quote(String str) {
-        return (str != null ? "'" + str + "'" : null);
+        return str != null ? "'" + str + "'" : null;
     }
 
     /**
@@ -483,7 +483,7 @@ public class StringUtils {
      *         if not a String
      */
     public static Object quoteIfString(Object obj) {
-        return (obj instanceof String ? quote((String) obj) : obj);
+        return obj instanceof String ? quote((String) obj) : obj;
     }
 
     /**
@@ -561,7 +561,7 @@ public class StringUtils {
             return null;
         }
         int separatorIndex = path.lastIndexOf(FOLDER_SEPARATOR);
-        return (separatorIndex != -1 ? path.substring(separatorIndex + 1) : path);
+        return separatorIndex != -1 ? path.substring(separatorIndex + 1) : path;
     }
 
     /**
@@ -726,8 +726,8 @@ public class StringUtils {
      */
     public static Locale parseLocaleString(String localeString) {
         String[] parts = tokenizeToStringArray(localeString, "_ ", false, false);
-        String language = (parts.length > 0 ? parts[0] : "");
-        String country = (parts.length > 1 ? parts[1] : "");
+        String language = parts.length > 0 ? parts[0] : "";
+        String country = parts.length > 1 ? parts[1] : "";
         validateLocalePart(language);
         validateLocalePart(country);
         String variant = "";
@@ -743,7 +743,7 @@ public class StringUtils {
                 variant = trimLeadingCharacter(variant, '_');
             }
         }
-        return (language.length() > 0 ? new Locale(language, country, variant) : null);
+        return language.length() > 0 ? new Locale(language, country, variant) : null;
     }
 
     private static void validateLocalePart(String localePart) {

--- a/src/main/java/org/audit4j/core/util/EnvUtil.java
+++ b/src/main/java/org/audit4j/core/util/EnvUtil.java
@@ -112,7 +112,7 @@ public class EnvUtil {
         ClassLoader classLoader = EnvUtil.class.getClassLoader();
         try {
             Class<?> bindingClass = classLoader.loadClass("org.codehaus.janino.ScriptEvaluator");
-            return (bindingClass != null);
+            return bindingClass != null;
         } catch (ClassNotFoundException e) {
             return false;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " UselessParenthesesCheck -     Useless parentheses around expressions should be removed to prevent any misunderstanding". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck


Please let me know if you have any questions.
Sameer Misger