### PR TITLE
Fixing squid:S2095- Resources should be closed -- Fixing squid:S1068-Unused private fields should be removed

### DIFF
--- a/src/main/java/org/audit4j/core/handler/file/FileAuditHandler.java
+++ b/src/main/java/org/audit4j/core/handler/file/FileAuditHandler.java
@@ -41,25 +41,7 @@ public class FileAuditHandler extends Handler implements Serializable {
 
     /** The writer. */
 	AuditFileWriter writer;
-
-	/** The archive. */
-	private String archive;
 	
-	/** The date pattern. */
-	private String datePattern;
-
-	/** The path. */
-	private String path;
-
-	/** The cron pattern. */
-	private String cronPattern;
-
-	/** The job. */
-	private AbstractArchiveJob job;
-	
-	/** The audit file prefix. */
-	private String auditFilePrefix = "Audit_Log-";
-
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -122,53 +104,6 @@ public class FileAuditHandler extends Handler implements Serializable {
 			return false;
 		}
 	}
-	
-	
-
-	/**
-	 * Sets the archive.
-	 *
-	 * @param archive the new archive
-	 */
-	public void setArchive(String archive) {
-		this.archive = archive;
-	}
-
-	/**
-	 * Sets the date pattern.
-	 *
-	 * @param datePattern the new date pattern
-	 */
-	public void setDatePattern(String datePattern) {
-		this.datePattern = datePattern;
-	}
-
-	/**
-	 * Sets the path.
-	 *
-	 * @param path the new path
-	 */
-	public void setPath(String path) {
-		this.path = path;
-	}
-
-	/**
-	 * Sets the cron pattern.
-	 *
-	 * @param cronPattern the new cron pattern
-	 */
-	public void setCronPattern(String cronPattern) {
-		this.cronPattern = cronPattern;
-	}
-
-	/**
-	 * Sets the audit file prefix.
-	 *
-	 * @param auditFilePrefix the new audit file prefix
-	 */
-	public void setAuditFilePrefix(String auditFilePrefix) {
-        this.auditFilePrefix = auditFilePrefix;
-    }
 
     /**
      * Stop.

--- a/src/main/java/org/audit4j/core/handler/file/MemoryMappedFileWriter.java
+++ b/src/main/java/org/audit4j/core/handler/file/MemoryMappedFileWriter.java
@@ -56,7 +56,7 @@ public class MemoryMappedFileWriter extends AuditFileWriter implements Serializa
 	@Override
 	public void init() {
 		int count = 10485760;
-		RandomAccessFile randomAccessFile;
+		RandomAccessFile randomAccessFile = null;
 		String realPath = FileHandlerUtil.generateOutputFilePath(path);
 
 		try {
@@ -71,6 +71,12 @@ public class MemoryMappedFileWriter extends AuditFileWriter implements Serializa
 			 out = randomAccessFile.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, count);
 		} catch (IOException e) {
 			e.printStackTrace();
+		} finally{
+			if(randomAccessFile != null){
+				try{
+					randomAccessFile.close();
+				}catch(IOException e){}
+			}
 		}
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "  squid:S2095- Resources should be closed --  squid:S1068- Unused private fields should be removed" information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S2095
https://dev.eclipse.org/sonar/rules/show/squid:S1068

Please let me know if you have any questions.
Sameer Misger