### PR TITLE
Fixing squid:S1126--Fixing squid:S1488

### DIFF
--- a/src/main/java/org/audit4j/core/Configurations.java
+++ b/src/main/java/org/audit4j/core/Configurations.java
@@ -80,8 +80,7 @@ public class Configurations {
      */
     static Configuration loadConfig(ConfigurationStream stream) throws ConfigurationException {
         ConfigProvider<Configuration> provider = getProviderByFileExtention(stream.getExtention());
-        Configuration configuration = provider.readConfig(stream.getInputStream());
-        return configuration;
+        return provider.readConfig(stream.getInputStream());
     }
 
     /**

--- a/src/main/java/org/audit4j/core/handler/file/FileHandlerUtil.java
+++ b/src/main/java/org/audit4j/core/handler/file/FileHandlerUtil.java
@@ -183,11 +183,7 @@ public final class FileHandlerUtil {
 	 */
 	public static boolean isFileAlreadyExists(String path) {
 		File file = new File(path);
-		if (file.exists()) {
-			return true;
-		} else {
-			return false;
-		}
+		return file.exists();
 	}
 
 	/**

--- a/src/main/java/org/audit4j/core/web/ServletContexConfigSupport.java
+++ b/src/main/java/org/audit4j/core/web/ServletContexConfigSupport.java
@@ -95,10 +95,6 @@ class ServletContexConfigSupport {
      */
     boolean hasHandlers(ServletContext servletContext) {
         String handlers = servletContext.getInitParameter("handlers");
-        if (handlers == null || handlers.equals("")) {
-            return false;
-        } else {
-            return true;
-        }
+        return !(handlers == null || handlers.equals(""));
     }
 }

--- a/src/test/java/org/audit4j/core/Audit4jTestBase.java
+++ b/src/test/java/org/audit4j/core/Audit4jTestBase.java
@@ -24,8 +24,7 @@ public class Audit4jTestBase {
         EventBuilder builder = new EventBuilder();
         builder.addTimestamp(new Date()).addActor(actor).addAction("myMethod").addOrigin("Origin").addField("myParam1Name", "param1")
                 .addField("myParam2Name", new Integer(2));
-        AuditEvent event = builder.build();
-        return event;
+        return builder.build();
     }
 
     protected Configuration getDefaultConfiguration() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1126-- Return of boolean expressions should not be wrapped into an "if-then-else" statement,  squid:S1488--  Local Variables should not be declared and then immediately returned or thrown" information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1126

Please let me know if you have any questions.
Sameer Misger