### PR TITLE
Fixing squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/audit4j/core/AuditManager.java
+++ b/src/main/java/org/audit4j/core/AuditManager.java
@@ -35,15 +35,15 @@ import org.audit4j.core.filter.AuditAnnotationFilter;
  */
 public final class AuditManager implements IAuditManager {
 
+    /** The audit manager. */
+    private static volatile IAuditManager auditManager;
+    
     /**
      * Instantiates a new audit manager.
      */
     private AuditManager() {
     }
 
-    /** The audit manager. */
-    private static volatile IAuditManager auditManager;
-    
     /**
      * Audit.
      * 

--- a/src/main/java/org/audit4j/core/Configuration.java
+++ b/src/main/java/org/audit4j/core/Configuration.java
@@ -64,13 +64,6 @@ public class Configuration implements Serializable {
     /** The jmx configurations. */
     private JMXConfig jmx;
     
-    /**
-     * Instantiates a new configuration.
-     */
-    public Configuration() {
-
-    }
-    
     /** Return new static instance. 
      * 
      * @since 2.3.1
@@ -82,6 +75,13 @@ public class Configuration implements Serializable {
      * @since 2.3.1
      * */
     public static Configuration DEFAULT = getDefault();
+    
+    /**
+     * Instantiates a new configuration.
+     */
+    public Configuration() {
+
+    }
     
     /**
      * Gets the default.

--- a/src/main/java/org/audit4j/core/Context.java
+++ b/src/main/java/org/audit4j/core/Context.java
@@ -95,6 +95,13 @@ public final class Context {
 	private static AnnotationTransformer annotationTransformer;
 
 	/**
+	 * Private singalton.
+	 */
+	private Context() {
+		// Nothing here. Private Constructor
+	}
+	
+	/**
 	 * Initialize the Audit4j instance. This will ensure the single audit4j
 	 * instance and single Configuration repository load in to the memory.
 	 */
@@ -459,10 +466,4 @@ public final class Context {
 		return lifeCycle.getStatus();
 	}
 
-	/**
-	 * Private singalton.
-	 */
-	private Context() {
-		// Nothing here. Private Constructor
-	}
 }

--- a/src/main/java/org/audit4j/core/LifeCycleContext.java
+++ b/src/main/java/org/audit4j/core/LifeCycleContext.java
@@ -19,6 +19,12 @@ public final class LifeCycleContext {
     private static LifeCycleContext instance;
 
     /**
+     * Instantiates a new context life cycle.
+     */
+    private LifeCycleContext() {
+    }
+    
+    /**
      * Gets the status.
      * 
      * @return the status
@@ -65,12 +71,6 @@ public final class LifeCycleContext {
      */
     void setStatus(RunStatus status) {
         this.status = status;
-    }
-
-    /**
-     * Instantiates a new context life cycle.
-     */
-    private LifeCycleContext() {
     }
 
     /**

--- a/src/main/java/org/audit4j/core/PreConfigurationContext.java
+++ b/src/main/java/org/audit4j/core/PreConfigurationContext.java
@@ -51,6 +51,13 @@ public final class PreConfigurationContext {
     /** The Constant preAnnotationFilters. */
     private static final List<AuditAnnotationFilter> preAnnotationFilters = new ArrayList<AuditAnnotationFilter>();
 
+    /**
+     * Instantiates a new registry.
+     */
+    private PreConfigurationContext() {
+        // Private Constructor
+    }
+
     static {
         ScanAnnotatedCommand scanAnnotated = new ScanAnnotatedCommand();
         availableCommands.add(scanAnnotated.getCommand());
@@ -130,13 +137,6 @@ public final class PreConfigurationContext {
      */
     public static List<AuditAnnotationFilter> getPreannotationfilters() {
         return preAnnotationFilters;
-    }
-
-    /**
-     * Instantiates a new registry.
-     */
-    private PreConfigurationContext() {
-        // Private Constructor
     }
 
 }

--- a/src/main/java/org/audit4j/core/command/CommandProcessor.java
+++ b/src/main/java/org/audit4j/core/command/CommandProcessor.java
@@ -39,7 +39,14 @@ public final class CommandProcessor {
 
     /** The instance. */
     private static CommandProcessor instance;
-
+    
+    /**
+     * Instantiates a new command processor.
+     */
+    private CommandProcessor(){
+        //Private Constructor.
+    }
+    
     /**
      * Process.
      *
@@ -80,13 +87,6 @@ public final class CommandProcessor {
         }
         
         process(commands);
-    }
-    
-    /**
-     * Instantiates a new command processor.
-     */
-    private CommandProcessor(){
-        //Private Constructor.
     }
     
     /**

--- a/src/main/java/org/audit4j/core/handler/file/archive/ArchiveType.java
+++ b/src/main/java/org/audit4j/core/handler/file/archive/ArchiveType.java
@@ -15,15 +15,6 @@ public enum ArchiveType {
     private String name;
 
     /**
-     * Gets the name.
-     * 
-     * @return the name
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
      * Instantiates a new archive type.
      * 
      * @param name
@@ -32,4 +23,14 @@ public enum ArchiveType {
     private ArchiveType(String name) {
         this.name = name;
     }
+    
+    /**
+     * Gets the name.
+     * 
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
 }

--- a/src/main/java/org/audit4j/core/handler/file/archive/Compression.java
+++ b/src/main/java/org/audit4j/core/handler/file/archive/Compression.java
@@ -14,6 +14,15 @@ public enum Compression {
     private String extention;
 
     /**
+     * Instantiates a new compression type.
+     *
+     * @param extention the extention
+     */
+    Compression(String extention) {
+        this.extention = extention;
+    }
+
+    /**
      * Gets the extention.
      *
      * @return the extention
@@ -22,12 +31,4 @@ public enum Compression {
         return extention;
     }
 
-    /**
-     * Instantiates a new compression type.
-     *
-     * @param extention the extention
-     */
-    Compression(String extention) {
-        this.extention = extention;
-    }
 }

--- a/src/main/java/org/audit4j/core/schedule/TaskUtils.java
+++ b/src/main/java/org/audit4j/core/schedule/TaskUtils.java
@@ -17,13 +17,6 @@ import org.audit4j.core.schedule.util.ErrorHandler;
  */
 public abstract class TaskUtils {
 	
-	/**
-     * private constructor to avoid instantiation of this class
-     */
-    private TaskUtils(){
-    	
-    }
-
     /**
      * An ErrorHandler strategy that will log the Exception but perform no
      * further handling. This will suppress the error so that subsequent
@@ -36,6 +29,13 @@ public abstract class TaskUtils {
      * a scheduled task.
      */
     public static final ErrorHandler LOG_AND_PROPAGATE_ERROR_HANDLER = new PropagatingErrorHandler();
+
+    /**
+     * private constructor to avoid instantiation of this class
+     */
+    private TaskUtils(){
+    	
+    }
 
     /**
      * Decorate the task for error handling. If the provided

--- a/src/main/java/org/audit4j/core/util/Base64Coder.java
+++ b/src/main/java/org/audit4j/core/util/Base64Coder.java
@@ -27,13 +27,6 @@ package org.audit4j.core.util;
  */
 public class Base64Coder {
 
-   /**
-    * Instantiates a new base64 coder.
-    */
-   private Base64Coder() {
-
-   }
-
    /** Holds The Constant LINE_SEPARATOR Value. */
    public static final String LINE_SEPARATOR = "line.separator";
 
@@ -99,6 +92,13 @@ public class Base64Coder {
        for (int i = 0; i < CONSTANT_64; i++) {
            map2[map1[i]] = (byte) i;
        }
+   }
+
+   /**
+    * Instantiates a new base64 coder.
+    */
+   private Base64Coder() {
+
    }
 
    /**

--- a/src/main/java/org/audit4j/core/util/ClassLoaderUtils.java
+++ b/src/main/java/org/audit4j/core/util/ClassLoaderUtils.java
@@ -10,6 +10,13 @@ package org.audit4j.core.util;
 public final class ClassLoaderUtils {
 
     /**
+     * Instantiates a new class loader utils.
+     */
+    private ClassLoaderUtils() {
+        super();
+    }
+
+    /**
      * Gets the class loader.
      *
      * @param clazz the clazz
@@ -33,10 +40,4 @@ public final class ClassLoaderUtils {
         return ClassLoader.getSystemClassLoader();
     }
 
-    /**
-     * Instantiates a new class loader utils.
-     */
-    private ClassLoaderUtils() {
-        super();
-    }
 }

--- a/src/main/java/org/audit4j/core/util/ConcurrentDateFormatAccess.java
+++ b/src/main/java/org/audit4j/core/util/ConcurrentDateFormatAccess.java
@@ -38,16 +38,6 @@ public class ConcurrentDateFormatAccess {
     /** The format. */
     private final String format;
 
-    /**
-     * Instantiates a new concurrent date format access.
-     *
-     * @param format the format
-     */
-    public ConcurrentDateFormatAccess(String format) {
-        super();
-        this.format = format;
-    }
-
     /** The date format. */
     private final ThreadLocal<DateFormat> dateFormat = new ThreadLocal<DateFormat>() {
         @Override
@@ -71,6 +61,16 @@ public class ConcurrentDateFormatAccess {
         }
 
     };
+
+    /**
+     * Instantiates a new concurrent date format access.
+     *
+     * @param format the format
+     */
+    public ConcurrentDateFormatAccess(String format) {
+        super();
+        this.format = format;
+    }
 
     /**
      * Convert string to date.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1213 -  The members of an interface declaration or class should appear in a pre-defined order". You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.
Sameer Misger