### PR TITLE
Add missing getDateFormat() method to SimpleLayout. Update call to deprecated generateFileOutput() in ZeroCopyfileWriter.write()

### DIFF
--- a/src/main/java/org/audit4j/core/handler/file/ZeroCopyFileWriter.java
+++ b/src/main/java/org/audit4j/core/handler/file/ZeroCopyFileWriter.java
@@ -82,7 +82,12 @@ public final class ZeroCopyFileWriter extends AuditFileWriter implements Seriali
      */
     @Override
     public ZeroCopyFileWriter write(String event) {
-        String realPath = FileHandlerUtil.generateOutputFilePath(path);
+//        String realPath = FileHandlerUtil.generateOutputFilePath(path);
+
+        String realPath = FileHandlerUtil.generateOutputFilePath(
+    			path, 
+    			FileHandlerUtil.generateAuditFileName());
+
         try {
             if (FileHandlerUtil.isFileAlreadyExists(realPath)) {
                 randomAccessFile = new RandomAccessFile(realPath, CoreConstants.READ_WRITE);

--- a/src/main/java/org/audit4j/core/layout/SimpleLayout.java
+++ b/src/main/java/org/audit4j/core/layout/SimpleLayout.java
@@ -91,4 +91,8 @@ public class SimpleLayout implements Layout {
     public void setDateFormat(String dateFormat) {
         this.dateFormat = dateFormat;
     }
+
+    public String getDateFormat() {
+    	return dateFormat;
+    }
 }


### PR DESCRIPTION
getDateFormat() was missing from SimpleLayout, causing the example shown in [7.1 Simple Layout](http://audit4j.org/documentation/#layout-simple) to fail.  Updated deprecated call to generateOutputFilePath() in ZeroCopyFileWriter, too.