### PR TITLE
Tests shouldn't rely on an audit4j.conf.yml file in user's home dir

### DIFF
--- a/src/main/java/org/audit4j/core/Configurations.java
+++ b/src/main/java/org/audit4j/core/Configurations.java
@@ -119,6 +119,7 @@ public class Configurations {
             fileStream = getClasspathResourceAsStream(CONFIG_FILE_NAME + "." + XML_EXTENTION);
             fileExtention = XML_EXTENTION;
         } else {
+
             String defaultConfigDir = System.getProperty("user.dir");
             String defaultConfigPath = scanConfigFile(defaultConfigDir);
             fileExtention = FilenameUtils.getExtension(defaultConfigPath);

--- a/src/test/java/org/audit4j/core/Int/event/annotation/DeIdentifyAnnotationTest.java
+++ b/src/test/java/org/audit4j/core/Int/event/annotation/DeIdentifyAnnotationTest.java
@@ -3,6 +3,7 @@ package org.audit4j.core.Int.event.annotation;
 import java.lang.reflect.Method;
 
 import org.audit4j.core.AuditManager;
+import org.audit4j.core.Configuration;
 import org.audit4j.core.IAuditManager;
 import org.audit4j.core.Mock.MethodAnnotationMock;
 import org.junit.After;
@@ -13,7 +14,7 @@ public class DeIdentifyAnnotationTest {
 
     @Before
     public void setup() {
-
+        AuditManager.startWithConfiguration(Configuration.DEFAULT);
     }
 
     @Test

--- a/src/test/java/org/audit4j/core/Int/event/annotation/IgnoreAuditAnnotationTest.java
+++ b/src/test/java/org/audit4j/core/Int/event/annotation/IgnoreAuditAnnotationTest.java
@@ -3,6 +3,7 @@ package org.audit4j.core.Int.event.annotation;
 import java.lang.reflect.Method;
 
 import org.audit4j.core.AuditManager;
+import org.audit4j.core.Configuration;
 import org.audit4j.core.IAuditManager;
 import org.audit4j.core.Mock.ClassAnnotationMock;
 import org.audit4j.core.util.Log;
@@ -15,7 +16,7 @@ public class IgnoreAuditAnnotationTest {
 
     @Before
     public void setup() {
-
+        AuditManager.startWithConfiguration(Configuration.DEFAULT);
     }
 
     @Test

--- a/src/test/java/org/audit4j/core/Int/event/annotation/MethodAnnotationTest.java
+++ b/src/test/java/org/audit4j/core/Int/event/annotation/MethodAnnotationTest.java
@@ -3,6 +3,7 @@ package org.audit4j.core.Int.event.annotation;
 import java.lang.reflect.Method;
 
 import org.audit4j.core.AuditManager;
+import org.audit4j.core.Configuration;
 import org.audit4j.core.Mock.MethodAnnotationMock;
 import org.audit4j.core.util.Log;
 import org.audit4j.core.util.StopWatch;
@@ -14,7 +15,7 @@ public class MethodAnnotationTest {
 
     @Before
     public void setup() {
-        AuditManager.getInstance();
+        AuditManager.startWithConfiguration(Configuration.DEFAULT);
     }
 
     @Test

--- a/src/test/java/org/audit4j/core/smoke/SmokeTest.java
+++ b/src/test/java/org/audit4j/core/smoke/SmokeTest.java
@@ -3,14 +3,21 @@ package org.audit4j.core.smoke;
 import java.util.concurrent.TimeUnit;
 
 import org.audit4j.core.AuditManager;
+import org.audit4j.core.Configuration;
 import org.audit4j.core.IAuditManager;
 import org.audit4j.core.dto.AuditEvent;
 import org.audit4j.core.dto.EventBuilder;
 import org.audit4j.core.util.Log;
 import org.audit4j.core.util.StopWatch;
+import org.junit.Before;
 import org.junit.Test;
 
 public class SmokeTest {
+
+    @Before
+    public void setup() {
+        AuditManager.startWithConfiguration(Configuration.DEFAULT);
+    }
 
     @Test
     public void smokeTestAuditEvent() throws InterruptedException {


### PR DESCRIPTION
Some of the tests expect an audit4j.conf.yml file to already exist in the user-directory (they use AuditManager.getInstance() without prior setup). On a clean clone of the code, a 'mvn test' will fail.
The tests should ensure a default configuration is loaded using AuditManager.startWithConfiguration(Configuration.DEFAULT).