### PR TITLE
[CLEAN] removing path variable of FileAuditHandler

### DIFF
--- a/src/main/java/org/audit4j/core/handler/file/FileAuditHandler.java
+++ b/src/main/java/org/audit4j/core/handler/file/FileAuditHandler.java
@@ -51,8 +51,6 @@ public class FileAuditHandler extends Handler implements Serializable {
 	/** The date pattern. */
 	private String datePattern;
 
-	/** The path. */
-	private String path;
 
 	/** The cron pattern. */
 	private String cronPattern;
@@ -146,14 +144,7 @@ public class FileAuditHandler extends Handler implements Serializable {
 		this.datePattern = datePattern;
 	}
 
-	/**
-	 * Sets the path.
-	 *
-	 * @param path the new path
-	 */
-	public void setPath(String path) {
-		this.path = path;
-	}
+
 
 	/**
 	 * Sets the cron pattern.

--- a/src/test/java/org/audit4j/core/handler/HandlerTest.java
+++ b/src/test/java/org/audit4j/core/handler/HandlerTest.java
@@ -1,5 +1,7 @@
 package org.audit4j.core.handler;
 
+import org.audit4j.core.dto.AuditEvent;
+import org.audit4j.core.dto.EventBatch;
 import org.audit4j.core.exception.HandlerException;
 import org.audit4j.core.exception.InitializationException;
 
@@ -26,6 +28,24 @@ public class HandlerTest extends Handler{
         // TODO Auto-generated method stub
         
     }
+
+	@Override
+	public void handle(String formattedEvent) throws HandlerException {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void handle(AuditEvent event) throws HandlerException {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void handle(EventBatch batch) throws HandlerException {
+		// TODO Auto-generated method stub
+		
+	}
     
 
 }


### PR DESCRIPTION
Variable path is confusing inside FileAuditHandler (the path is defined in property "log.file.location")
So the quick solution is to remove it