### PR TITLE
a little contribution

### DIFF
--- a/src/main/java/org/audit4j/core/DefaultAnnotationTransformer.java
+++ b/src/main/java/org/audit4j/core/DefaultAnnotationTransformer.java
@@ -77,7 +77,7 @@ public class DefaultAnnotationTransformer implements AnnotationTransformer<Audit
 			// Extract Actor
 			String annotationAction = audit.action();
 			if (ACTION.equals(annotationAction)) {
-				event.setAction(annotationEvent.getMethod().getName());
+				event.setAction(annotationEvent.getMethod().getDeclaringClass().getName() + "." +annotationEvent.getMethod().getName());
 			} else {
 				event.setAction(annotationAction);
 			}
@@ -133,6 +133,7 @@ public class DefaultAnnotationTransformer implements AnnotationTransformer<Audit
 		int i = 0;
 		String paramName = null;
 		for (final Annotation[] annotations : parameterAnnotations) {
+			paramName = method.getParameters()[i].getName();
 			final Object object = params[i++];
 			boolean ignoreFlag = false;
 			DeIdentify deidentify = null;

--- a/src/main/java/org/audit4j/core/handler/file/ZeroCopyFileWriter.java
+++ b/src/main/java/org/audit4j/core/handler/file/ZeroCopyFileWriter.java
@@ -30,6 +30,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 
+import org.apache.commons.io.IOUtils;
 import org.audit4j.core.CoreConstants;
 
 /**
@@ -128,6 +129,18 @@ public final class ZeroCopyFileWriter extends AuditFileWriter implements Seriali
 
         } catch (IOException e) {
             e.printStackTrace();
+        } finally {
+            IOUtils.closeQuietly(inputStream);
+            try {
+                fileChannel.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            try {
+                randomAccessFile.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
         return this;
     }


### PR DESCRIPTION
I have done some optimization for audit4j after using this for some time,  including 
1. print precise argument name instead of arg0, 1....
2. deep size check to avoid infinite recursion (manual skip http request/response/session heavy objects, maybe you can expose configuration to skip  user custom class , eg joda  LocalDateTime, LocalDate )
3. release resource to avoid too many open files in Linux , this is fatal, there was an existed issue opened raised by someone found in solaris