### PR TITLE
correctly detects java versions above java 8

### DIFF
--- a/src/main/java/org/audit4j/core/Context.java
+++ b/src/main/java/org/audit4j/core/Context.java
@@ -18,10 +18,6 @@
 
 package org.audit4j.core;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.audit4j.core.command.CommandProcessor;
 import org.audit4j.core.command.impl.BatchCommand;
 import org.audit4j.core.command.impl.MetadataCommand;
@@ -316,7 +312,7 @@ public final class Context {
 		// Check java support.!
 		boolean javaSupport = EnvUtil.isJDK7OrHigher();
 		if (!javaSupport) {
-			Log.error("Your Java version (", EnvUtil.getJavaersion(), ") is not supported for Audit4j. ",
+			Log.error("Your Java version (", EnvUtil.getJavaVersion(), ") is not supported for Audit4j. ",
 					ErrorGuide.getGuide(ErrorGuide.JAVA_VERSION_ERROR));
 			throw new InitializationException("Java version is not supported.");
 		}

--- a/src/main/java/org/audit4j/core/util/EnvUtil.java
+++ b/src/main/java/org/audit4j/core/util/EnvUtil.java
@@ -18,13 +18,10 @@
 
 package org.audit4j.core.util;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
+import org.audit4j.core.Configurations;
 
 import javax.servlet.ServletContext;
-
-import org.audit4j.core.Configurations;
+import java.io.File;
 
 /**
  * The Class EnvUtil.
@@ -40,36 +37,6 @@ public class EnvUtil {
     private EnvUtil(){
     	
     }
-    
-    /**
-     * Checks if is jD k_ n_ or higher.
-     * 
-     * @param n
-     *            the n
-     * @return true, if is jD k_ n_ or higher
-     */
-    private static boolean isJDK_N_OrHigher(int n) {
-        List<String> versionList = new ArrayList<String>();
-        // this code should work at least until JDK 10 (assuming n parameter is
-        // always 6 or more)
-        for (int i = 0; i < 5; i++) {
-            //Till JDK 1.8 versioning is 1.x after 10 its will JDK N.x
-            if(n + i<10)
-            versionList.add("1." + (n + i));
-            else
-            versionList.add((n + i)+".");
-        }
-
-        String javaVersion = System.getProperty("java.version");
-        if (javaVersion == null) {
-            return false;
-        }
-        for (String v : versionList) {
-            if (javaVersion.startsWith(v))
-                return true;
-        }
-        return false;
-    }
 
     /**
      * Checks if is jD k5.
@@ -77,7 +44,7 @@ public class EnvUtil {
      * @return true, if is jD k5
      */
     static public boolean isJDK5() {
-        return isJDK_N_OrHigher(5);
+        return JavaVersion.isJDK_N_OrHigher(5, getJavaVersion());
     }
 
     /**
@@ -86,7 +53,7 @@ public class EnvUtil {
      * @return true, if is jD k6 or higher
      */
     static public boolean isJDK6OrHigher() {
-        return isJDK_N_OrHigher(6);
+        return JavaVersion.isJDK_N_OrHigher(6, getJavaVersion());
     }
 
     /**
@@ -95,17 +62,17 @@ public class EnvUtil {
      * @return true, if is jD k7 or higher
      */
     static public boolean isJDK7OrHigher() {
-        return isJDK_N_OrHigher(7);
+        return JavaVersion.isJDK_N_OrHigher(7, getJavaVersion());
     }
 
 
     /**
-     * Gets the javaersion.
+     * Gets the java version.
      * 
-     * @return the javaersion
+     * @return the java version
      */
-    public static String getJavaersion() {
-        return System.getProperty("java.version");
+    public static String getJavaVersion() {
+        return JavaVersion.current();
     }
 
     /**

--- a/src/main/java/org/audit4j/core/util/EnvUtil.java
+++ b/src/main/java/org/audit4j/core/util/EnvUtil.java
@@ -25,22 +25,22 @@ import java.io.File;
 
 /**
  * The Class EnvUtil.
- * 
+ *
  * @author <a href="mailto:janith3000@gmail.com">Janith Bandara</a>
  */
 public class EnvUtil {
 
-	  
+
     /**
      * private constructor to avoid instantiation of this class
      */
     private EnvUtil(){
-    	
+
     }
 
     /**
      * Checks if is jD k5.
-     * 
+     *
      * @return true, if is jD k5
      */
     static public boolean isJDK5() {
@@ -49,7 +49,7 @@ public class EnvUtil {
 
     /**
      * Checks if is jD k6 or higher.
-     * 
+     *
      * @return true, if is jD k6 or higher
      */
     static public boolean isJDK6OrHigher() {
@@ -58,17 +58,28 @@ public class EnvUtil {
 
     /**
      * Checks if is jD k7 or higher.
-     * 
+     *
      * @return true, if is jD k7 or higher
      */
     static public boolean isJDK7OrHigher() {
         return JavaVersion.isJDK_N_OrHigher(7, getJavaVersion());
     }
 
+    /**
+     * Gets the javaersion
+     *
+     * @deprecated renamed this method. use {@link EnvUtil#getJavaVersion()} instead.
+     *
+     * @return the javaersion
+     */
+    @Deprecated
+    public static String getJavaersion() {
+        return getJavaVersion();
+    }
 
     /**
      * Gets the java version.
-     * 
+     *
      * @return the java version
      */
     public static String getJavaVersion() {
@@ -77,7 +88,7 @@ public class EnvUtil {
 
     /**
      * Checks if is janino available.
-     * 
+     *
      * @return true, if is janino available
      */
     static public boolean isJaninoAvailable() {
@@ -92,7 +103,7 @@ public class EnvUtil {
 
     /**
      * Checks if is servlet spec 3 or higher.
-     * 
+     *
      * @param context
      *            the context
      * @return true, if is servlet spec3 or higher
@@ -106,7 +117,7 @@ public class EnvUtil {
 
     /**
      * Checks if is windows.
-     * 
+     *
      * @return true, if is windows
      */
     public static boolean isWindows() {

--- a/src/main/java/org/audit4j/core/util/JavaVersion.java
+++ b/src/main/java/org/audit4j/core/util/JavaVersion.java
@@ -1,0 +1,39 @@
+package org.audit4j.core.util;
+
+/*
+
+java.version is a system property that exists in every JVM. There are two possible formats for it:
+
+    Java 8 or lower: 1.6.0_23, 1.7.0, 1.7.0_80, 1.8.0_211
+    Java 9 or higher: 9.0.1, 11.0.4, 12, 12.0.1
+
+ */
+public class JavaVersion {
+    /**
+     * Checks if is jD k_ n_ or higher.
+     *
+     * @param n
+     *            the n
+     * @return true, if is jD k_ n_ or higher
+     */
+    static boolean isJDK_N_OrHigher(int n, String javaVersion) {
+        try {
+            final String[] versionParts = javaVersion.split("\\.");
+
+            int version;
+            if ("1".equals(versionParts[0])) {
+                version = Integer.parseInt(versionParts[1]);
+            } else {
+                version = Integer.parseInt(versionParts[0]);
+            }
+            return version >= n;
+        } catch (Exception e) {
+            // swallow any error and return false to maintain previous behaviour of defaulting to false
+            return false;
+        }
+    }
+
+    public static String current() {
+        return System.getProperty("java.version");
+    }
+}

--- a/src/test/java/org/audit4j/core/util/JavaVersionTest.java
+++ b/src/test/java/org/audit4j/core/util/JavaVersionTest.java
@@ -1,0 +1,49 @@
+package org.audit4j.core.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Parameterized.class)
+public class JavaVersionTest {
+
+    public JavaVersionTest(final int javaVersion, final String javaSystemProperty) {
+        this.javaVersion = javaVersion;
+        this.javaSystemProperty = javaSystemProperty;
+    }
+
+    @Parameterized.Parameters(name = "{index}: checking java({0}) with version string {1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+          { 6, "1.6.0_23"},
+          { 7, "1.7.0_80"},
+          { 8, "1.8.0_211"},
+          { 9, "9.0.1"},
+          { 10, "10.0.1"},
+          { 11, "11.0.4"},
+          { 12, "12"}
+        });
+    }
+
+    private final int javaVersion;
+    private final String javaSystemProperty;
+
+    @Test
+    public void canDetectWhetherJavaVersionIsHigherThanAGivenValue() {
+        final List<Integer> javaVersions = Arrays.asList(5, 6, 7, 8, 9, 10, 11, 12, 13);
+
+        for (final Integer version : javaVersions) {
+            assertThat(
+              "java version " + javaVersion + " with description " + javaSystemProperty + " was not correctly detected as higher than java " + version,
+              JavaVersion.isJDK_N_OrHigher(version, javaSystemProperty),
+              is(version <= javaVersion));
+        }
+    }
+}


### PR DESCRIPTION
Here's a possible solution to #85 

The java version checker called for the system property directly which made it hard to test so I've pulled that behaviour separate to the `EnvUtils` that contained it and inject the system property

This let me write parameterised tests to check a range of java versions.

I spotted that `EnvUtil.getJavaVersion` was (I'm assuming) typoed as `EnvUtil.getJavaersion` so fixed that too.