### PR TITLE
Add support for JDKs up to v16

### DIFF
--- a/src/main/java/org/audit4j/core/util/EnvUtil.java
+++ b/src/main/java/org/audit4j/core/util/EnvUtil.java
@@ -50,9 +50,9 @@ public class EnvUtil {
      */
     private static boolean isJDK_N_OrHigher(int n) {
         List<String> versionList = new ArrayList<String>();
-        // this code should work at least until JDK 10 (assuming n parameter is
+        // this code should work at least until JDK 16 (assuming n parameter is
         // always 6 or more)
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 10; i++) {
             //Till JDK 1.8 versioning is 1.x after 10 its will JDK N.x
             if(n + i<10)
             versionList.add("1." + (n + i));

--- a/src/main/java/org/audit4j/core/util/EnvUtil.java
+++ b/src/main/java/org/audit4j/core/util/EnvUtil.java
@@ -53,7 +53,7 @@ public class EnvUtil {
         // this code should work at least until JDK 16 (assuming n parameter is
         // always 6 or more)
         for (int i = 0; i < 10; i++) {
-            //Till JDK 1.8 versioning is 1.x after 10 its will JDK N.x
+            //Till JDK 1.8 versioning is 1.x after 9 its will JDK N.x
             if(n + i<10)
             versionList.add("1." + (n + i));
             else


### PR DESCRIPTION
This is a short-term fix that allows consumers to use the project as-is,
but ideally we would move to a more resilient setup that may support
future JDK versions.

Closes #85.

---

Note that this has been tested on JDK8 and JDK11, nothing newer.